### PR TITLE
Bump mysql cookbook to version 5.6.1

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ version          '0.4.0'
 supports         'ubuntu'
 
 depends 'apt'
-depends 'mysql', '5.5.2'
+depends 'mysql', '5.6.1'
 depends 'database'
 depends 'hostsfile'
 depends 'java'


### PR DESCRIPTION
This seems to fix an issue wherein the mysql cookbook never restarts mysqld after updating its configuration (and thus does not create the socket file)
