### PR TITLE
Reference metadata in berksfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,3 @@
 source 'https://supermarket.getchef.com'
 
 metadata
-
-cookbook 'hostsfile'


### PR DESCRIPTION
Now fixed to remove the redundant reference to `hostsfile`
